### PR TITLE
QHotKey pri file has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [projects](https://github.com/ArsenArsen/KShare/projects)
 |:----:|:--:|
 |Arch Linux (development)|[kshare-git](https://aur.archlinux.org/packages/kshare-git/)|
 |Ubuntu (development)|[Ubuntu .deb](https://nativeci.arsenarsen.com/job/KShare/lastSuccessfulBuild/artifact/packages/simpleName.deb)|
-|Arch Linux |[kshare](https://aur.archlinux.org/packages/kshare-git/)|
+|Arch Linux |[kshare](https://aur.archlinux.org/packages/kshare/)|
 |Ubuntu |[Ubuntu .deb](https://nativeci.arsenarsen.com/job/KShare%20Stable/lastSuccessfulBuild/artifact/packages/simpleName.deb	)|
 
 I do plan to make a Debian packages.


### PR DESCRIPTION
It is now at vendor/vendor.pri. When I tried to install, the QHotKey folder had nothing in, and we had the new vendor directory with the pri file. 

Details [here](https://github.com/Skycoder42/QHotkey/commit/4446fe0a42a92acd94523148f6213d1383dfaf39)