### PR TITLE
Add URL-Encoding to base64

### DIFF
--- a/src/uploaders/customuploader.cpp
+++ b/src/uploaders/customuploader.cpp
@@ -265,7 +265,7 @@ QJsonObject recurseAndReplace(QJsonObject &body, QByteArray &data, QString forma
 void CustomUploader::doUpload(QByteArray imgData, QString format) {
     auto h = getHeaders(headers, format, this->rFormat);
     QByteArray data;
-    if (base64) imgData = imgData.toBase64();
+    if (base64) imgData = imgData.toBase64(QByteArray::Base64UrlEncoding);
 
     switch (this->rFormat) {
     case RequestFormat::PLAIN: {


### PR DESCRIPTION
Adding QByteArray::Base64UrlEncoding to the args of imgData.toBase64() will add better compatibility when sending it over to something like PHP or JS. Essentially, it replaces all spaces with - . You could also do QByteArray::Base64Encoding which will replace all spaces with + instead of -. However, the - tends to work better amongst other things.

This is pretty much to give better support for POSTing the base64 code to a RESTful receiver on a website or something. Either arg is better than nothing.

See: https://doc.qt.io/qt-5/qbytearray.html#toBase64-1